### PR TITLE
Add Scan QR code from clipboard

### DIFF
--- a/praesentia/static/praesentia.js
+++ b/praesentia/static/praesentia.js
@@ -8,28 +8,27 @@ let html5QrcodeScanner = new Html5QrcodeScanner(
 
 html5QrcodeScanner.render(onScanSuccess);
 
-const target = document.querySelector('body');
-
-target.addEventListener('paste', (event) => {
-    let paste = event.clipboardData || window.clipboardData;
+$('body').on('paste', event => {
+    let paste = event.originalEvent.clipboardData || window.clipboardData;
 
     if(paste.files.length > 0) {
         html5QrcodeScanner.html5Qrcode.scanFile(paste.files[0], true)
         .then(decodedText => {
-            processingDecodedText(decodedText)
+            processDecodedText(decodedText)
         })
         .catch(err => {
-            swal.fire('Error', 'Cannot read QR Code, Please make sure paste only the QR Code', 'error');
+            swal.fire('Error', 'Cannot read QR code. Please make sure to only paste a QR code image.', 'error');
         });
     }
+
+    event.preventDefault()
 });
 
-
 function onScanSuccess(decodedText, _) {
-    processingDecodedText(decodedText)
+    processDecodedText(decodedText)
 }
 
-function processingDecodedText(decodedText) {
+function processDecodedText(decodedText) {
     $('#qrData').text(decodedText.slice(0, 20) + '...');
     qrData = decodedText;
     $('#reader__dashboard_section_csr > span:nth-child(2) > button:nth-child(2)').click();

--- a/praesentia/static/praesentia.js
+++ b/praesentia/static/praesentia.js
@@ -6,10 +6,30 @@ let html5QrcodeScanner = new Html5QrcodeScanner(
         qrbox: 250,
     });
 
-
 html5QrcodeScanner.render(onScanSuccess);
 
+const target = document.querySelector('body');
+
+target.addEventListener('paste', (event) => {
+    let paste = event.clipboardData || window.clipboardData;
+
+    if(paste.files.length > 0) {
+        html5QrcodeScanner.html5Qrcode.scanFile(paste.files[0], true)
+        .then(decodedText => {
+            processingDecodedText(decodedText)
+        })
+        .catch(err => {
+            swal.fire('Error', 'Cannot read QR Code, Please make sure paste only the QR Code', 'error');
+        });
+    }
+});
+
+
 function onScanSuccess(decodedText, _) {
+    processingDecodedText(decodedText)
+}
+
+function processingDecodedText(decodedText) {
     $('#qrData').text(decodedText.slice(0, 20) + '...');
     qrData = decodedText;
     $('#reader__dashboard_section_csr > span:nth-child(2) > button:nth-child(2)').click();

--- a/praesentia/templates/home.html
+++ b/praesentia/templates/home.html
@@ -47,7 +47,10 @@
                 </div>
                 <div id="reader_container">
                     <div id="reader" width="600px" class="mb-3"></div>
-                </div>
+                    <small><strong>ProTip!</strong> You can scan your QR code image from your clipboard, just
+                        <kbd>ctrl</kbd>+<kbd>v</kbd>
+                        it here.</small>
+                </div><br>
                 <label><span id="hasQrData">✓</span> QR Data: <code id="qrData">-</code></label><br>
                 <div class="pure-g">
                     <div class="pure-u" style="margin-right: 1rem;">


### PR DESCRIPTION
this PR close #2 

The idea is to use [paste event](https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event) and then grab the files object from `event.clipboardData`

```
[praesentia.js]
....
const target = document.querySelector('body');

target.addEventListener('paste', (event) => {
    let paste = event.clipboardData || window.clipboardData;

    if(paste.files.length > 0) {
        html5QrcodeScanner.html5Qrcode.scanFile(paste.files[0], true)
        .then(decodedText => {
            processingDecodedText(decodedText)
        })
        .catch(err => {
            swal.fire('Error', 'Cannot read QR Code, Please make sure paste only the QR Code', 'error');
        });
    }
});
....
```

When the file object exist, call method `scanFile` from class `html5Qrcode`. it will return `decodedText` if successful and when fail will call `swal.fire`

### CAUTION
`html5Qrcode` instance is private field from `html5QrcodeScanner` see [this file on line (87)](https://github.com/mebjas/html5-qrcode/blob/bc2eb18d4d08226b4ea48a7403ca5e4590369ecb/src/html5-qrcode-scanner.ts#L76). the problem can be solved by creating `html5Qrcode` directly (use [Pro Mode](https://github.com/mebjas/html5-qrcode#pro-mode---if-you-want-to-implement-your-own-user-interface) as it says on the documentation)

### For demo visit this [link](https://drive.google.com/uc?id=1t_Wm5PlJA7CkWagMAn9Qj-jR_D85Fnff)