### PR TITLE
Fix bad logic flow in `processQrImage()`

### DIFF
--- a/praesentia/static/praesentia.js
+++ b/praesentia/static/praesentia.js
@@ -3,9 +3,9 @@ QrScanner.WORKER_PATH = 'static/qr-scanner/qr-scanner-worker.min.js';
 let qrData = '';
 let capture, worker;
 
-function processQrImage(file, ignore_error = false) {
+function processQrImage(file, hide_alert = false) {
     $('#qrData').text('scanning...');
-    QrScanner.scanImage(file, null, worker).then((decodedText) => {
+    return QrScanner.scanImage(file, null, worker).then((decodedText) => {
         qrData = decodedText;
         $('#qrData').text(decodedText.slice(0, 20) + '...');
         $('#btnSubmit').focus();
@@ -13,14 +13,15 @@ function processQrImage(file, ignore_error = false) {
             $('#btnSubmit').click();
         }
         $('#hasQrData').show();
-        $('#btnStopScreenSharing').click();
+        return true;
     }).catch(err => {
-        if (!ignore_error)
+        if (!hide_alert)
             swal.fire('Error', 'Cannot read QR code. ' +
                 'Please make sure that it is an image that contains a QR code.', 'error');
         $('#qrImageFile').val('');
         $('#hasQrData').hide();
         $('#qrData').text('-');
+        return false;
     });
 }
 
@@ -47,7 +48,9 @@ function randomizeLatLong() {
 
 async function scanVideoStream(imageData) {
     const image = await createImageBitmap(imageData);
-    processQrImage(image, true);
+    if (await processQrImage(image, true)) {
+        stopCapture();
+    }
 };
 
 async function startCapture() {

--- a/praesentia/templates/home.html
+++ b/praesentia/templates/home.html
@@ -113,7 +113,7 @@
             It's open source, see it on <a href="https://github.com/p4kl0nc4t/praesentia">GitHub</a>.
         </p>
         <footer>
-            <small>Praesentia v1.2.0</small>
+            <small>Praesentia v1.2.1</small>
         </footer>
 
     </div>


### PR DESCRIPTION
This PR fixes #17. It turns out that the bug is caused by a bad logic in the `processQrImage()` function. The function will always execute `$('#btnStopScreenSharing').click();` which also triggers `stopCapture()`. If `capture` is not already initialized (by starting to share screen), the `processQrImage()` will always end up in an error.

### Summary
1. `processQrImage()` function won't call `$('#btnStopScreenSharing').click();` by itself
2. `processQrImage()` function now returns a Promise that indicate the status of the QR scan
3. To compensate point (1), small necessary adjustment is done to the `scanVideoStream()` function.