### PR TITLE
New feature: log in by using a session token

### DIFF
--- a/praesentia/simaster.py
+++ b/praesentia/simaster.py
@@ -23,7 +23,7 @@ class SimasterQrPresence:
         self.a_id = a_id if a_id else self._generate_random_a_id()
         self.logged_in = False
         self.session_id = None
-        self.account_data = {}
+        self.group_id = None
         self.session = requests.Session()
         self.session.headers.update(self.HEADERS)
 
@@ -41,10 +41,22 @@ class SimasterQrPresence:
         data = req.json()
         self.session_id = data['sesId']
         self.group_id = data['groupMenu']
-        self.account_data['name'] = data['namaLengkap']
-        self.account_data['group'] = data['groupMenuNama']
-        self.account_data['id'] = data['userTipeNomor']
         return self._commit_device()
+
+
+    def load_session(self, serialized_session):
+        try:
+            _, session_id, group_id = serialized_session.split(':')
+        except ValueError:
+            return False
+
+        self.session_id = session_id
+        self.group_id = group_id
+        self.logged_in = True
+        return True
+
+    def serialize_session(self):
+        return f'token:{self.session_id}:{self.group_id}'
 
     def send_qr_presence(self, qr_data, lat, long):
         token = self._request_token()

--- a/praesentia/static/style.css
+++ b/praesentia/static/style.css
@@ -42,6 +42,14 @@
     box-sizing: border-box;
 }
 
+.token {
+    margin-top: 1rem;
+    font-family: monospace;
+    color: grey;
+    font-size: x-small;
+    word-wrap: break-word;
+}
+
 footer {
     color: grey;
     text-align: center;

--- a/praesentia/templates/home.html
+++ b/praesentia/templates/home.html
@@ -24,8 +24,10 @@
                 <label for="username">UGM ID:</label>
                 <input type="text" id="username" class="pure-input-1" placeholder="john.doe1998">
                 <span class="pure-form-message">without "@mail.ugm.ac.id" suffix</span>
-                <label for="password">Password:</label>
-                <input type="password" class="pure-input-1" id="password">
+                <div id="passwordContainer">
+                    <label for="password">Password:</label>
+                    <input type="password" class="pure-input-1" id="password">
+                </div>
                 <label class="pure-checkbox">
                     <input type="checkbox" id="hurry">
                     huRRy! mode <small>(randomize lat/long)</small>


### PR DESCRIPTION
I have recently faced a problem where I have to share my username and password when trying to "ensure" my presence.

This PR has mainly changed the logging in logic. This PR contains changes that made it possible to log in with a session token instead of a username and a password. This way, if in some scenario, a user won't have to share their credentials.

A "session token" is actually just a string comprised of a logged in `SimasterQRPresence` instance's `session_id` and `group_id`. Some new methods (a way to serialize and deserialize a session token) have also been added to `simaster.py` file.

From the front perspective, the `home.html` has also been changed. After logging in, there will be a small text displayed on the alert box that contains the last session token.