### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9-alpine
+WORKDIR /app
+COPY . .
+RUN pip install -r requirements.txt
+CMD ["gunicorn", "-b", ":8000", "wsgi:app"]
+EXPOSE 8000


### PR DESCRIPTION
This PR only adds Dockerfile. This is to prepare for the migration to another platform (likely Render).

Signed-off-by: Faiz Jazadi <me@lcat.dev>